### PR TITLE
refactor(translator): update prompt version from 1 to 3

### DIFF
--- a/src/translator.cpp
+++ b/src/translator.cpp
@@ -8,7 +8,7 @@ constexpr const char* kJsonContentTypeHeader = "Content-Type: application/json";
 constexpr const char* kAuthorizationHeaderPrefix = "Authorization: Bearer ";
 constexpr const char* kResponsesPath = "/v1/responses";
 constexpr const char* kPromptId = "pmpt_6a0f01bb349481979917ee0c1d43fe4b0952c8d49f597498";
-constexpr const char* kPromptVersion = "1";
+constexpr const char* kPromptVersion = "3";
 
 size_t writeResponseCallback(char* contents, size_t size, size_t nmemb, void* user_data)
 {


### PR DESCRIPTION
This pull request makes a minor update to the `src/translator.cpp` file, specifically updating the prompt version constant from `"1"` to `"3"`. This change likely points the code to use a newer version of a prompt or API.

* Updated the value of `kPromptVersion` from `"1"` to `"3"` in `src/translator.cpp` to reference the latest prompt version.